### PR TITLE
Remove target ID floating health

### DIFF
--- a/cfg/settings.cfg
+++ b/cfg/settings.cfg
@@ -33,3 +33,4 @@ alias cl_showfps ""
 volume 0.5
 hud_fastswitch 1
 cl_hud_minmode 1
+tf_hud_target_id_disable_floating_health 1


### PR DESCRIPTION
Not sure where should this cvar go, but since the last update you need it to disable the floating health hud element in the default hud so here it goes.
