### PR TITLE
Cleaned up and added xhair Cvars to static.cfg

### DIFF
--- a/lwrt/csgo/config/cfg/static.cfg
+++ b/lwrt/csgo/config/cfg/static.cfg
@@ -1,39 +1,48 @@
 // These settings will always be executed on game launch
 // You can customize it however you like
 
-engine_no_focus_sleep 0
 
+// Debut & Utility Cvars
+engine_no_focus_sleep 0
+net_graph 0
+cl_showfps 0
+
+// Recording Cvars
 host_timescale 0
 host_framerate 0
 
-net_graph 0
-
-cl_showfps 0
+// HUD Cvars
 cl_draw_only_deathnotices 1
+mp_display_kill_assists 0 // 0 Disables assists in death notices | 1 enables.
+gameinstructor_enable 0 // Disables visual tips in-game.
+hud_takesshots 0
+hud_showtargetid 0
+hidehud 8329
+hidehud 8320
+
+
+// View-model Cvars
 cl_bob_lower_amt 5
 cl_bobamt_lat 0.1
 cl_bobamt_vert 0.1
 cl_bobcycle 0.98
 cl_viewmodel_shift_left_amt 0.5
 cl_viewmodel_shift_right_amt 0.25
-cl_crosshairsize 4
-cl_crosshairgap 1.5
-cl_crosshairdot 0
-cl_crosshair_drawoutline 0
-cl_crosshairthickness 0.8
-
-gameinstructor_enable 0
-
-hidehud 8329
-hidehud 8320
-
-hud_takesshots 0
-hud_showtargetid 0
-
-mat_postprocess_enable 0
-
-mp_display_kill_assists 0
-
 viewmodel_offset_x 2
 viewmodel_offset_y 2
 viewmodel_offset_z -2
+
+// Cross-hair Cvars
+crosshair 1
+cl_crosshairsize 4
+cl_crosshaircolor 5
+cl_crosshaircolor_r 255
+cl_crosshaircolor_g 255
+cl_crosshaircolor_b 255
+cl_crosshairgap 0
+cl_crosshairdot 0
+cl_crosshair_drawoutline 0
+cl_crosshairthickness .5
+
+// Visual Cvars
+mat_postprocess_enable 0

--- a/lwrt/csgo/config/cfg/static.cfg
+++ b/lwrt/csgo/config/cfg/static.cfg
@@ -33,7 +33,6 @@ viewmodel_offset_y 2
 viewmodel_offset_z -2
 
 // Cross-hair Cvars
-crosshair 1
 cl_crosshairsize 4
 cl_crosshaircolor 5
 cl_crosshaircolor_r 255


### PR DESCRIPTION
Cleaned up static.cfg and added default crosshair cvars, as to not have unintended values assigned left over from the user cfg.